### PR TITLE
Not intended for merging: expose ignore match metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bstr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +132,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "glob"
@@ -232,6 +250,7 @@ dependencies = [
 name = "ignore"
 version = "0.4.20"
 dependencies = [
+ "bitvec",
  "crossbeam-channel",
  "globset",
  "lazy_static",
@@ -385,6 +404,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "regex"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,3 +606,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -19,6 +19,7 @@ name = "ignore"
 bench = false
 
 [dependencies]
+bitvec = "1.0.1"
 globset = { version = "0.4.10", path = "../globset" }
 lazy_static = "1.1"
 log = "0.4.5"

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
-name = "ignore"
-version = "0.4.20"  #:version
+name = "tree_sitter_grep_ignore"
+version = "0.4.20-dev.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
+(A forked version of `ignore` used internally by `tree-sitter-grep`)
+
 A fast library for efficiently matching ignore files such as `.gitignore`
 against file paths.
 """

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -260,6 +260,7 @@ pub const DEFAULT_TYPES: &[(&str, &[&str])] = &[
     ]),
     ("thrift", &["*.thrift"]),
     ("toml", &["*.toml", "Cargo.lock"]),
+    ("treesitterquery", &["*.scm"]),
     ("ts", &["*.ts", "*.tsx", "*.cts", "*.mts"]),
     ("twig", &["*.twig"]),
     ("txt", &["*.txt"]),

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -23,7 +23,9 @@ use std::sync::{Arc, RwLock};
 use crate::gitignore::{self, Gitignore, GitignoreBuilder};
 use crate::overrides::{self, Override};
 use crate::pathutil::{is_hidden, strip_prefix};
-use crate::types::{self, Types};
+use crate::types::{
+    self, FileTypeDef, FileTypeIndicesTokenIterator, MatchMetadataToken, Types,
+};
 use crate::walk::DirEntry;
 use crate::{Error, Match, PartialErrorBuilder};
 
@@ -38,7 +40,7 @@ pub struct IgnoreMatch<'a>(IgnoreMatchInner<'a>);
 enum IgnoreMatchInner<'a> {
     Override(overrides::Glob<'a>),
     Gitignore(&'a gitignore::Glob),
-    Types(types::Glob<'a>),
+    Types(types::Globs),
     Hidden,
 }
 
@@ -51,12 +53,19 @@ impl<'a> IgnoreMatch<'a> {
         IgnoreMatch(IgnoreMatchInner::Gitignore(x))
     }
 
-    fn types(x: types::Glob<'a>) -> IgnoreMatch<'a> {
+    fn types(x: types::Globs) -> IgnoreMatch<'a> {
         IgnoreMatch(IgnoreMatchInner::Types(x))
     }
 
     fn hidden() -> IgnoreMatch<'static> {
         IgnoreMatch(IgnoreMatchInner::Hidden)
+    }
+
+    pub fn match_metadata_token(&self) -> Option<MatchMetadataToken> {
+        match &self.0 {
+            IgnoreMatchInner::Types(globs) => globs.match_metadata_token(),
+            _ => None,
+        }
     }
 }
 
@@ -506,6 +515,60 @@ impl Ignore {
     /// one exists.
     fn absolute_base(&self) -> Option<&Path> {
         self.0.absolute_base.as_ref().map(|p| &***p)
+    }
+
+    pub fn get_match_metadata<'self_>(
+        &'self_ self,
+        match_metadata_token: MatchMetadataToken,
+    ) -> MatchMetadata<'self_> {
+        MatchMetadata {
+            matching_file_types: MatchingFileTypesIterator::new(
+                self,
+                match_metadata_token,
+            ),
+        }
+    }
+
+    pub fn get_file_type_def_at_selection_index(
+        &self,
+        selection_index: usize,
+    ) -> &FileTypeDef {
+        self.0.types.get_file_type_def_at_selection_index(selection_index)
+    }
+}
+
+pub struct MatchMetadata<'a> {
+    pub matching_file_types: MatchingFileTypesIterator<'a>,
+}
+
+pub struct MatchingFileTypesIterator<'a> {
+    ignore: &'a Ignore,
+    file_type_indices_iterator: FileTypeIndicesTokenIterator,
+}
+
+impl<'a> MatchingFileTypesIterator<'a> {
+    pub fn new(
+        ignore: &'a Ignore,
+        match_metadata_token: MatchMetadataToken,
+    ) -> Self {
+        Self {
+            ignore,
+            file_type_indices_iterator: match match_metadata_token {
+                MatchMetadataToken::FileTypeIndicesToken(
+                    file_type_indices_token,
+                ) => file_type_indices_token.into_iter(),
+            },
+        }
+    }
+}
+
+impl<'a> Iterator for MatchingFileTypesIterator<'a> {
+    type Item = &'a FileTypeDef;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.file_type_indices_iterator.next().map(|file_type_index| {
+            self.ignore.get_file_type_def_at_selection_index(file_type_index)
+        })
     }
 }
 

--- a/crates/ignore/src/dir.rs
+++ b/crates/ignore/src/dir.rs
@@ -535,6 +535,32 @@ impl Ignore {
     ) -> &FileTypeDef {
         self.0.types.get_file_type_def_at_selection_index(selection_index)
     }
+
+    pub fn should_skip_entry_with_match_metadata_token(
+        &self,
+        dent: &DirEntry,
+    ) -> (bool, Option<MatchMetadataToken>) {
+        let m = self.matched_dir_entry(dent);
+        if m.is_ignore() {
+            log::debug!("ignoring {}: {:?}", dent.path().display(), m);
+            (
+                true,
+                m.inner().and_then(|ignore_match| {
+                    ignore_match.match_metadata_token()
+                }),
+            )
+        } else if m.is_whitelist() {
+            log::debug!("whitelisting {}: {:?}", dent.path().display(), m);
+            (
+                false,
+                m.inner().and_then(|ignore_match| {
+                    ignore_match.match_metadata_token()
+                }),
+            )
+        } else {
+            (false, None)
+        }
+    }
 }
 
 pub struct MatchMetadata<'a> {

--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -44,8 +44,6 @@ for result in WalkBuilder::new("./").hidden(false).build() {
 See the documentation for `WalkBuilder` for many other options.
 */
 
-#![deny(missing_docs)]
-
 use std::error;
 use std::fmt;
 use std::io;

--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -49,6 +49,7 @@ use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 
+pub use crate::dir::MatchMetadata;
 pub use crate::walk::{
     DirEntry, ParallelVisitor, ParallelVisitorBuilder, Walk, WalkBuilder,
     WalkParallel, WalkState,


### PR DESCRIPTION
In this PR:
- expose "match metadata" (really just "which specified file types did this file match") to consumers of `ignore` `WalkParallel` file matches

This is pretty "dirty" (in terms of eg API exposed) and just doing what it needs to to support the `tree-sitter-grep` use case

Not in this PR:
- I haven't added any test coverage within `ignore` for this yet

To test:
Basically for files returned by `WalkParallel` that correspond to one or more "whitelisted file-types" you should get back a populated `MatchMetadata` that lets you iterate over those `FileTypeDef`'s that it corresponded to